### PR TITLE
1.前端不再需要后台验证token,因此将token相关注解类和方法拦截类标注为过时,注释掉所有接口上的相关注解

### DIFF
--- a/src/main/java/com/HexTechGDUT/controller/AnimalController.java
+++ b/src/main/java/com/HexTechGDUT/controller/AnimalController.java
@@ -49,7 +49,7 @@ public class AnimalController {
      * 查询所有动物
      * @return recordList 结果集
      */
-    @PassToken
+//    @PassToken
     @ApiOperation("查询全部动物")
     @GetMapping("queryAll")
     public Result<List<QueryAllAnimalsBo>> queryAllAnimals(long current, long limit){
@@ -93,7 +93,7 @@ public class AnimalController {
      * @param animalId 动物id
      * @return 结果
      */
-    @PassToken
+//    @PassToken
     @ApiOperation("查询一条动物记录")
     @GetMapping("queryOneAnimal")
     public Result<AnimalRecord> queryOneAnimal(Integer animalId){
@@ -109,7 +109,7 @@ public class AnimalController {
      * @param animalRecord 动物信息类
      * @return 结果
      */
-    @AuthToken
+//    @AuthToken
     @ApiOperation("插入一条动物记录")
     @PostMapping("insertAnimal")
     public Result<String> insertAnimal(@RequestBody AnimalRecord animalRecord){
@@ -132,7 +132,7 @@ public class AnimalController {
      * @param animalRecord 动物信息实体类
      * @return 结果
      */
-    @AuthToken
+//    @AuthToken
     @ApiOperation("更新动物记录")
     @PostMapping("updateAnimal")
     public Result<String> updateAnimal(@RequestBody AnimalRecord animalRecord){
@@ -151,7 +151,7 @@ public class AnimalController {
      * @param animalQuery 条件查询Vo类：包含动物昵称、最后出现的地点、动物中列、状态、记录类型5个属性
      * @return animalRecordList 包含动物信息的List
      */
-    @PassToken
+//    @PassToken
     @ApiOperation("通过多种条件查询动物")
     @PostMapping("queryAnimal")
     public Result<PageQueryAnimalBo> queryAnimal(long current,long limit, @RequestBody AnimalQuery animalQuery){
@@ -211,7 +211,7 @@ public class AnimalController {
      * @param id 动物id
      * @return 是否删除成功
      */
-    @AuthToken
+//    @AuthToken
     @ApiOperation("通过动物id删除动物")
     @DeleteMapping({"{id}"})
     public Result<String> deleteAnimalRecord(@PathVariable int id){

--- a/src/main/java/com/HexTechGDUT/controller/ApplicationController.java
+++ b/src/main/java/com/HexTechGDUT/controller/ApplicationController.java
@@ -25,7 +25,7 @@ public class ApplicationController {
     @Resource
     private ApplicationService applicationService;
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("提交申请")
     @PostMapping("/apply")
     public Result<Application> apply(@Validated @RequestBody Application application){
@@ -36,7 +36,7 @@ public class ApplicationController {
         return ResultUtils.failWithInfo(null,"提交失败");
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("取消申请")
     @PostMapping("/cancel")
     public Result<String> cancel(@Validated @RequestBody int id){
@@ -46,7 +46,7 @@ public class ApplicationController {
         return ResultUtils.fail("取消失败");
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("用户修改申请")
     @PostMapping("/update")
     public Result<String> update(@Validated @RequestBody Application application){
@@ -57,7 +57,7 @@ public class ApplicationController {
         return ResultUtils.fail("更新失败");
     }
 
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("管理员处理申请")
     @PostMapping("/process")
     public Result<String> process(@Validated @RequestBody Application application){
@@ -67,7 +67,7 @@ public class ApplicationController {
         return ResultUtils.fail("处理失败");
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("通过申请id查询申请")
     @PostMapping("/queryApplicationById")
     public Result<Application> queryApplicationById(@Validated @RequestBody int id){
@@ -78,7 +78,7 @@ public class ApplicationController {
         return ResultUtils.success(application);
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("通过动物id查询申请")
     @PostMapping("/queryApplicationByAnimalId")
     public  Result<List<Application>> queryApplicationByAnimalId(@Validated @RequestBody int animalId){
@@ -89,7 +89,7 @@ public class ApplicationController {
         return ResultUtils.success(applicationList);
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("通过申请状态查询申请")
     @PostMapping("/queryApplicationByStatus")
     public  Result<List<Application>> queryApplicationByStatus(@Validated @RequestBody int status){
@@ -100,7 +100,7 @@ public class ApplicationController {
         return ResultUtils.success(applicationList);
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("通过用户id查询申请")
     @PostMapping("/queryApplicationByUserId")
     public  Result<List<Application>> queryApplicationByUserId(@Validated @RequestBody String userId){

--- a/src/main/java/com/HexTechGDUT/controller/CommentController.java
+++ b/src/main/java/com/HexTechGDUT/controller/CommentController.java
@@ -25,7 +25,7 @@ public class CommentController {
     @Resource
     private CommentService commentService;
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("发布评论")
     @PostMapping("/publish")
     public Result<Comment> publish(@Validated @RequestBody Comment comment){
@@ -35,7 +35,7 @@ public class CommentController {
         return ResultUtils.failWithInfo(null,"发布失败");
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("删除评论")
     @PostMapping("/delete")
     public Result<String> delete(@Validated @RequestBody int id){
@@ -45,7 +45,7 @@ public class CommentController {
         return ResultUtils.fail("删除失败");
     }
 
-    @PassToken
+//    @PassToken
     @ApiOperation("通过动物id查询评论")
     @PostMapping("/queryCommentByAnimalId")
     public Result<List<Comment>> queryCommentByAnimalId(@Validated @RequestBody int animalId){
@@ -56,7 +56,7 @@ public class CommentController {
         return ResultUtils.success(comments);
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("通过用户id查询评论")
     @PostMapping("/queryCommentByUserId")
     public Result<List<Comment>> queryCommentByUserId(@Validated @RequestBody String userId){

--- a/src/main/java/com/HexTechGDUT/controller/TipsController.java
+++ b/src/main/java/com/HexTechGDUT/controller/TipsController.java
@@ -34,7 +34,7 @@ public class TipsController {
      * @param tips tips
      * @return result of tips
      */
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("发布文章")
     @PostMapping("/publish")
     public Result<Tips> publish(@ApiParam("提示") @Validated @RequestBody Tips tips){
@@ -50,7 +50,7 @@ public class TipsController {
      * @param tips tips
      * @return result of tips
      */
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("更新文章")
     @PostMapping("/update")
     public Result<Tips> update(@ApiParam("提示") @Validated @RequestBody Tips tips){
@@ -61,7 +61,7 @@ public class TipsController {
         return ResultUtils.failWithInfo(null, "发布文章失败");
     }
 
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("删除文章")
     @ApiImplicitParam(name = "id", value = "文章id", dataType = "Integer",required = true)
     @PostMapping("/delete")
@@ -77,7 +77,7 @@ public class TipsController {
      * 无需登录即可查询tips
      * @return tips list
      */
-    @PassToken
+//    @PassToken
     @ApiOperation("查询全部文章")
     @GetMapping("/queryAllTips")
     public Result<List<Tips>> queryAllTips(){
@@ -88,7 +88,7 @@ public class TipsController {
         return ResultUtils.success(tipsList);
     }
 
-    @PassToken
+//    @PassToken
     @ApiOperation("随机查询一篇文章")
     @GetMapping("/queryRandomTips")
     public Result<Tips> queryRandomTips(){
@@ -104,7 +104,7 @@ public class TipsController {
      * @param id id
      * @return tips
      */
-    @PassToken
+//    @PassToken
     @ApiOperation("根据文章id查询文章")
     @ApiImplicitParam(name = "id", value = "文章id", dataType = "Integer", required = true)
     @PostMapping("/queryTipsById")
@@ -121,7 +121,7 @@ public class TipsController {
      * @param title tips 标题
      * @return tips list
      */
-    @PassToken
+//    @PassToken
     @ApiOperation("根据题目模糊查询文章")
     @ApiImplicitParam(name = "title", value = "标题", dataType = "String", required = true)
     @PostMapping("/queryTipsLikeTitle")

--- a/src/main/java/com/HexTechGDUT/controller/UserController.java
+++ b/src/main/java/com/HexTechGDUT/controller/UserController.java
@@ -3,9 +3,7 @@ package com.HexTechGDUT.controller;
 import com.HexTechGDUT.entity.bo.UidAndPwdBo;
 import com.HexTechGDUT.entity.po.User;
 import com.HexTechGDUT.result.Result;
-import com.HexTechGDUT.security.AuthToken;
-import com.HexTechGDUT.security.PassToken;
-import com.HexTechGDUT.service.TokenService;
+import com.HexTechGDUT.security.TokenService;
 import com.HexTechGDUT.service.UserService;
 import com.HexTechGDUT.utils.ResultUtils;
 import io.swagger.annotations.Api;
@@ -33,7 +31,7 @@ public class UserController {
     @Resource
     private TokenService tokenService;
 
-    @PassToken
+//    @PassToken
     @ApiOperation("注册")
     @PostMapping("/register")
     public Result<String> register(@Validated @RequestBody UidAndPwdBo uidAndPwdBo){
@@ -44,21 +42,27 @@ public class UserController {
         return ResultUtils.failWithInfo(null, "注册失败");
     }
 
-    @PassToken
+//    @PassToken
     @ApiOperation("登录")
     @PostMapping("/login")
     public Result<String> login(@Validated @RequestBody UidAndPwdBo uidAndPwdBo){
         return ResultUtils.successWithInfo(userService.login(uidAndPwdBo), "登录成功");
     }
 
-    @PassToken
+    @ApiOperation("刷新token的过期时间")
+    @PostMapping("refreshToken")
+    public Result<String> refreshToken(@Validated @RequestBody String oldToken){
+        return ResultUtils.success(tokenService.refresh(oldToken));
+    }
+
+//    @PassToken
     @ApiOperation("根据token获取用户id")
     @PostMapping("getUserIdByToken")
     public Result<String> getUserIdByToken(@Validated @RequestBody String token){
         return ResultUtils.success(tokenService.getTokenUserId(token));
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("更新用户信息")
     @PostMapping("/update")
     public Result<String> update(@Validated @RequestBody User user){
@@ -69,7 +73,7 @@ public class UserController {
         return ResultUtils.fail("更新失败");
     }
 
-    @AuthToken
+//    @AuthToken
     @ApiOperation("删除用户")
     @ApiImplicitParam(name = "userId", value = "要删除的用户id", dataType = "String", required = true)
     @PostMapping("/delete")
@@ -81,7 +85,7 @@ public class UserController {
         return ResultUtils.fail("更新失败");
     }
 
-    @PassToken
+//    @PassToken
     @ApiOperation("通过请求头携带的token查询用户")
     @PostMapping("queryUserByToken")
     public Result<User> queryUserByToken(@Validated @RequestBody String token){
@@ -93,20 +97,20 @@ public class UserController {
         return ResultUtils.success(user);
     }
 
-    @AuthToken(value = 1)
-    @ApiOperation("通过用户id查询用户")
-    @ApiImplicitParam(name = "userId", value = "用户id", dataType = "String", required = true)
-    @PostMapping("/queryUserByUserId")
-    public Result<User> queryUserByUserId(@Validated @RequestBody String userId){
-        User user = userService.queryUserByUserId(userId);
-        if(user == null){
-            return ResultUtils.failWithInfo(null, "用户不存在");
-        }
-        user.setPassword("");
-        return ResultUtils.success(user);
-    }
+//    @AuthToken(value = 1)
+//    @ApiOperation("通过用户id查询用户")
+//    @ApiImplicitParam(name = "userId", value = "用户id", dataType = "String", required = true)
+//    @PostMapping("/queryUserByUserId")
+//    public Result<User> queryUserByUserId(@Validated @RequestBody String userId){
+//        User user = userService.queryUserByUserId(userId);
+//        if(user == null){
+//            return ResultUtils.failWithInfo(null, "用户不存在");
+//        }
+//        user.setPassword("");
+//        return ResultUtils.success(user);
+//    }
 
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("通过名字模糊查询用户")
     @ApiImplicitParam(name = "name", value = "用户名", dataType = "String", required = true)
     @PostMapping("/queryUserLikeName")
@@ -121,7 +125,7 @@ public class UserController {
         return ResultUtils.success(userList);
     }
 
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("通过地址模糊查询用户")
     @ApiImplicitParam(name = "address", value = "用户联系地址", dataType = "String", required = true)
     @PostMapping("/queryUserLikeAddress")
@@ -136,7 +140,7 @@ public class UserController {
         return ResultUtils.success(userList);
     }
 
-    @AuthToken(value = 1)
+//    @AuthToken(value = 1)
     @ApiOperation("通过用户权限查询用户")
     @ApiImplicitParam(name = "type", value = "用户类型：1-管理员,0-普通用户", dataType = "Integer", required = true)
     @PostMapping("/queryUserByUserType")

--- a/src/main/java/com/HexTechGDUT/security/AuthToken.java
+++ b/src/main/java/com/HexTechGDUT/security/AuthToken.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Target;
  * 带有该注解表示http请求必须带有token
  * @author HexTechGDUT
  */
+@Deprecated
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthToken {

--- a/src/main/java/com/HexTechGDUT/security/AuthenticationInterceptor.java
+++ b/src/main/java/com/HexTechGDUT/security/AuthenticationInterceptor.java
@@ -1,8 +1,6 @@
 package com.HexTechGDUT.security;
 
-import com.HexTechGDUT.service.TokenService;
 import com.HexTechGDUT.service.UserService;
-import com.HexTechGDUT.service.impl.JwtTokenServiceImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
@@ -17,6 +15,7 @@ import java.lang.reflect.Method;
 /**
  * @author HexTechGDUT
  */
+@Deprecated
 @Component
 public class AuthenticationInterceptor implements HandlerInterceptor {
 
@@ -29,7 +28,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest httpServletRequest,
                              @Nullable HttpServletResponse httpServletResponse,
-                             @Nullable Object object) throws Exception {
+                             @Nullable Object object) {
         // 从 http 请求头中取出 token
         String token = httpServletRequest.getHeader("token");
         // 如果不是映射到方法直接通过

--- a/src/main/java/com/HexTechGDUT/security/InterceptorConfig.java
+++ b/src/main/java/com/HexTechGDUT/security/InterceptorConfig.java
@@ -8,6 +8,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 /**
  * @author HexTechGDUT
  */
+@Deprecated
 @Configuration
 public class InterceptorConfig implements WebMvcConfigurer {
 

--- a/src/main/java/com/HexTechGDUT/security/JwtTokenServiceImpl.java
+++ b/src/main/java/com/HexTechGDUT/security/JwtTokenServiceImpl.java
@@ -1,7 +1,6 @@
-package com.HexTechGDUT.service.impl;
+package com.HexTechGDUT.security;
 
 import com.HexTechGDUT.entity.po.User;
-import com.HexTechGDUT.service.TokenService;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -60,6 +59,15 @@ public class JwtTokenServiceImpl implements TokenService {
                 //token过期的时间
                 .withExpiresAt(expiresDate)
                 .sign(Algorithm.HMAC256(SECRET));
+    }
+
+    @Override
+    public String refresh(String token) {
+        DecodedJWT jwt = JWT.decode(token);
+        User user = new User();
+        user.setUserId(jwt.getAudience().get(0));
+        user.setUserType(jwt.getClaims().get("auth").asInt());
+        return generate(user);
     }
 
     @Override

--- a/src/main/java/com/HexTechGDUT/security/PassToken.java
+++ b/src/main/java/com/HexTechGDUT/security/PassToken.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Target;
  * 该注解表示http请求无需token
  * @author HexTechGDUT
  */
+@Deprecated
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PassToken {

--- a/src/main/java/com/HexTechGDUT/security/TokenService.java
+++ b/src/main/java/com/HexTechGDUT/security/TokenService.java
@@ -1,4 +1,4 @@
-package com.HexTechGDUT.service;
+package com.HexTechGDUT.security;
 
 import com.HexTechGDUT.entity.po.User;
 
@@ -16,6 +16,12 @@ public interface TokenService{
      */
     String generate(User user);
 
+    /**
+     * 刷新token的过期时间
+     * @param token old token
+     * @return new token
+     */
+    String refresh(String token);
     /**
      * 验证Token
      * 验证成功什么也不做

--- a/src/main/java/com/HexTechGDUT/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/HexTechGDUT/service/impl/UserServiceImpl.java
@@ -3,7 +3,7 @@ package com.HexTechGDUT.service.impl;
 import com.HexTechGDUT.entity.bo.UidAndPwdBo;
 import com.HexTechGDUT.dao.UserMapper;
 import com.HexTechGDUT.entity.po.User;
-import com.HexTechGDUT.service.TokenService;
+import com.HexTechGDUT.security.TokenService;
 import com.HexTechGDUT.service.UserService;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;

--- a/src/test/java/com/HexTechGDUT/service/TokenServiceTest.java
+++ b/src/test/java/com/HexTechGDUT/service/TokenServiceTest.java
@@ -1,6 +1,7 @@
 package com.HexTechGDUT.service;
 
 import com.HexTechGDUT.entity.po.User;
+import com.HexTechGDUT.security.TokenService;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -36,5 +37,21 @@ public class TokenServiceTest {
         user.setUserType(1);
         String token = tokenService.generate(user);
         System.out.println(tokenService.getTokenUserId(token));
+    }
+
+    @Test
+    public void refreshTest(){
+        User user = new User();
+        user.setUserId("test_u1");
+        user.setPassword("test_p1");
+        user.setUserType(1);
+//        String token = tokenService.generate(user);
+//        System.out.println(token);
+//        try{
+//            Thread.sleep(2000);
+//        }catch (Exception e){
+//            e.printStackTrace();
+//        }
+//        System.out.println(tokenService.refresh(token));
     }
 }


### PR DESCRIPTION
2.保留获取token的接口和通过token获取用户id的接口
3.新增刷新token过期时间的接口,可能会有用
4.使用(通过token获取用户)替换(通过用户id获取用户)